### PR TITLE
Initial commit, Alpha release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 This Plugin is an extension for the [Teams for WooCommerce Memberships](https://woocommerce.com/products/teams-woocommerce-memberships/) plugin.
 
-It enables public access to specific Team Membership's content to requests based on request Client's IP address.
+It enables public access to normally restricted Team Membership's content, based on the IP address of the client request.
 
 ## Usage
 
-The plugin adds a simple settings Section to the `WooCommerce` > `Settings` > `Memberships`, called "Team Access by IP".
+This plugin adds a simple settings Section to the `WooCommerce` > `Settings` > `Memberships`, called "Team Access by IP".
 
-These settings allow the site admin to enter IPv4 addresses and/or IPv4 address ranges for all existing Team Memberships. 
+In those settings, you can associate custom IPv4 addresses and/or IPv4 address ranges to any existing Team Membership. 
 
-For browser requests coming from those IP addresses, it enables public viewing (no login or registration needed) of all the Posts which that particular Team Membership Plan is able to view.  
+For browser requests coming from those IP addresses, it enables public viewing of all the Posts (no login or registration needed) which that particular Team Membership is able to view based on their Membership Plan settings.  

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This Plugin is an extension for the [Teams for WooCommerce Memberships](https://woocommerce.com/products/teams-woocommerce-memberships/) plugin.
 
-It enables public access to normally restricted Team Membership's content, based on the IP address of the client request.
+It enables public access to Team Membership's restricted content based on visitor's IP address.
 
 ## Usage
 
@@ -10,4 +10,4 @@ This plugin adds a simple settings Section to the `WooCommerce` > `Settings` > `
 
 In those settings, you can associate custom IPv4 addresses and/or IPv4 address ranges to any existing Team Membership. 
 
-For browser requests coming from those IP addresses, it enables public viewing of all the Posts (no login or registration needed) which that particular Team Membership is able to view based on their Membership Plan settings.  
+For browser requests coming from those client IP addresses, it enables public viewing of all the Posts (no login or registration needed) which that particular Team Membership is able to view based on their Membership Plan settings.  


### PR DESCRIPTION
This is an initial release for a new repo. Check out the brief [README](https://github.com/Automattic/newspack-teams-for-wc-memberships-access-by-ip).

Kindly asking for a thorough review of this initial commit. I pushed this Alpha directly to `master`, and created this dummy branch so that I may create a PR based on something. Please review the full content of the `master` including:
- project setup: scaffolding, PHP, config review
- plugin and PHP code
- do a test run of the steps below
- phpunit tests were written for a helper class -- running those is optional

## This plugin

This plugin works on top of the [Teams for WooCommerce Memberships](https://woocommerce.com/products/teams-woocommerce-memberships/), and it enables public access to a Team Membership restricted content based on the visitor's IP address.

## Test site setup

- any WP site, Newspack is not required
- install "WooCommerce" (no need to run the Setup Wizard), "WooCommerce Memberships" and "WooCommerce Teams for Memberships"
- simply activate this plugin (no building required)

### Configure the test site:

Step 1 -- create some test content:
- first create 2 Posts
    - set titles "Test post 1", and "Test post 2", and add with plenty of _lorem ipsum_ content to see the content restriction messages from WooComm
    - make sure that the checkbox _"Check this box if you want to force the content to be public regardless of any restriction rules that may apply now or in the future"_ in the "Membership" section under the Block Editor is checked **OFF** (it should already be turned OFF on a blank site)
    - just in case you have the "newspack-woocomm-memberships-auto-archive" set up on this site, make sure not to use that feature right now, and to have the Auto Archive turned OFF
    - publish these two posts

Step 2 -- create two test Membership Plans:
- in WooCommerce > Memberships > Membership Plans, create two Plans:
    - name them "Plan 1" and "Plan 2"
- on the Plan editing screen, open the "Restricted Content" tab, and add one simple rule to each of these Plans:
    - for "Plan 1" add Rule `Type`=Posts, `Accessible`=Immediately, and under `Title` enter "Test post 1"
    - for "Plan 2" add Rule `Type`=Posts, `Accessible`=Immediately, and under `Title` enter "Test post 2"
    - publish these Plans

Step 3 -- create test Team Memberships:
- in WooCommerce > Memberships > Teams, create two Teams:
    - name therm "Team 1" and "Team 2"
    - in the Details tab on the right side, set "Plan 1" for "Team 1", and "Plan 2" for "Team 2"
    - update the Teams

Step 4 -- confirm that the content is restricted
- open an incognito window, and test view "Test post 1" and "Test post 2" in their separate incognito tabs, as a non-registered non-logged in user
- confirm that both of these posts are restricted content to non logged in users
- keep this incognito window with posts open, as it will be useful during the next testing steps

## Test public access by IP:
- next, open the new section added by this Plugin -- go to WooCommerce > Settings > Memberships and open the new section below called "Team Access by IP"
- you may first test save some valid and invalid entries, to verifty that the validation works well:
  - enter a valid IPv4, then an invalid one, and notice the error message
  - enter a valid IPv4 address range, then an invalid one, also check the error messages
  - enter a duplicate IP address, or an overlapping address&range, and check the error messages
- to continue testing, find out what your client's IP is -- execute the `get_client_ip()` function which is [located right here](https://github.com/Automattic/newspack-teams-for-wc-memberships-access-by-ip/blob/master/plugin/class-plugin.php#L160) to get your client's IP. It's quite possible that your address is `192.168.50.1` too, if you're using a local Vagrant box for these tests
- enter your IP address into "Team 1", and leave "Team 2" blank
- go to your incognito window, and confirm that you're able to view the full contents of "Test post 1", but not "Test post 2"
- next reverse the Teams-IPs -- set your IP address to "Team 2" and leave "Team 1"'s IPs blank
- confirm that you can now only view "Test Post 2" fully as public
- you may test using IP ranges, too. E.g instead of `192.168.50.1` you could enter `192.168.49.200-192.168.50.100`, and that should work just the same