### PR TITLE
Access by IP, added message in header

### DIFF
--- a/plugin/class-plugin.php
+++ b/plugin/class-plugin.php
@@ -153,7 +153,7 @@ class Plugin {
 				if ( ! $team_name ) {
 					return;
 				}
-				echo sprintf( '<div id="%s">%s<div>',
+				echo sprintf( '<div id="%s">%s</div>',
 					'access-by-ip-msg-div',
 					$team_name . __( " has a subscription for unlimited access to Transitions." )
 				);

--- a/plugin/class-plugin.php
+++ b/plugin/class-plugin.php
@@ -133,7 +133,7 @@ class Plugin {
 			$restricted_content->query_vars['post__in']
 		);
 
-		// Make this Post public.
+		// Make this Post public, and display the user-faced message.
 		if ( $can_plan_access_this_post ) {
 			add_filter(
 				'wc_memberships_is_post_public',
@@ -147,6 +147,17 @@ class Plugin {
 				10,
 				3
 			);
+
+			$team_name = $team->get_name();
+			add_action( 'wp_body_open', function() use ( $team_name ) {
+				if ( ! $team_name ) {
+					return;
+				}
+				echo sprintf( '<div id="%s">%s<div>',
+					'access-by-ip-msg-div',
+					$team_name . __( " has a subscription for unlimited access to Transitions." )
+				);
+			} );
 		}
 
 		return $post;


### PR DESCRIPTION
## This PR

Re: Zendesk Ticket https://woothemes.zendesk.com/agent/tickets/3406603

If a premium content is viewed from a special IP, a message needs to be displayed to the user informing them about who is providing this content to them. This PR outputs the message in a `div` with a unique `id` and I kindly ask @laurelfulford to please help with some custom CSS to style it appropriately

## The Test Site

A test site `tol-adevp-test.newspackstaging.com` was created as a playground.

### To Use the Test Site:
- login to https://tol-adevp-test.newspackstaging.com/wp-admin using [these Secret Store creds](https://mc.a8c.com/secret-store/?secret_id=6874)
- disable the Password Protected plugin for a little while
- open an incognito window (completely non-logged in and public faced), and open a premium post, for example [this one](https://tol-adevp-test.newspackstaging.com/client/article/a-generation-upended.html)
- fist notice that the content is not being displayed, and that there's a gray box with the "You have reached a premium content area of TOL..." message in the post content area
- next, to find out what  your IP is, I made a little helper debugging option -- enter an URL with the `_output_my_ip_dbg` GET variable, e.g `https://tol-adevp-test.newspackstaging.com/client/article/a-generation-upended.html?_output_my_ip_dbg` then view the page source and search for the `_output_my_ip_dbg` string in the source to get your IP:
![image](https://user-images.githubusercontent.com/29167323/100367909-32306680-3003-11eb-83be-7eae8ab4bd9f.png)
- with your IP address, go to the [WooComm Teams access by IP settings page](https://tol-adevp-test.newspackstaging.com/wp-admin/admin.php?page=wc-settings&tab=memberships&section=newspack_teams_for_wc_memberships_access_by_ip) and add your IP to a Team, then click save at the bottom of the settings page
- now go back to the incognito window and view the same post again. It should have become public to you, and the message is now output at the top:
![image](https://user-images.githubusercontent.com/29167323/100368432-dd412000-3003-11eb-8097-a0a570d434b1.png)

### The CSS
This message is output by using the `wp_body_open` hook, and displays inside a `<div id="access-by-ip-msg-div">` right after the `body` opening tag. If there's a better or more convenient way to output it, this can be changed, and please recommend a better solution here, and I'll update it. Otherwise, I'd kindly ask if you could generate a custom CSS for this, > Appearance:
```
#access-by-ip-msg-div{ }
```

### After we're done

Please re-enable the Password Protected plugin on this test site.